### PR TITLE
修复128*64屏幕限制导致动画分段问题

### DIFF
--- a/WouoUI-128_64/WouoUI-128_64.ino
+++ b/WouoUI-128_64/WouoUI-128_64.ino
@@ -889,7 +889,7 @@ void animation(float *a, float *a_trg, uint8_t n)
 {
   if (*a != *a_trg)
   {
-    if (fabs(*a - *a_trg) < 0.15f) *a = *a_trg;
+    if (fabs(*a - *a_trg) < 1.0f) *a = *a_trg;
     else *a += (*a_trg - *a) / (ui.param[n] / 10.0f);
   }
 }


### PR DESCRIPTION
您好！
很喜欢非线性动画的效果，然而在这个动画在低速率动画下会导致结束前一段的帧界面都不变，而最后一帧跳动一个像素，从而造成视觉上动画函数分段的情况。
原代码是判断距离小于0.15时才使其相等，我修改成了屏幕最小的位移单位1。